### PR TITLE
These should be commented out by default according to ReadMe

### DIFF
--- a/Recipes/_Application Requirements Template.xml
+++ b/Recipes/_Application Requirements Template.xml
@@ -12,8 +12,8 @@
 			<PrefetchScript>Add-LogContent "Starting Global Requirements Script: `"$ScriptRoot\ExtraFiles\Scripts\CreateGlobalConditionsAndRequirements.ps1`"";
 			Invoke-Expression "&amp; `"$ScriptRoot\ExtraFiles\Scripts\CreateGlobalConditionsAndRequirements.ps1`"";
 			# Un-Comment the Lines Below to Package Microsoft Surface Drivers
-			Add-LogContent "Updating Microsoft Surface Drivers Recipes";
-			Invoke-Expression "&amp; `"$ScriptRoot\ExtraFiles\Scripts\CreateMicrosoftDriverRecipes.ps1`"";
+			# Add-LogContent "Updating Microsoft Surface Drivers Recipes";
+			# Invoke-Expression "&amp; `"$ScriptRoot\ExtraFiles\Scripts\CreateMicrosoftDriverRecipes.ps1`"";
 			</PrefetchScript>
 			<URL>https://raw.githubusercontent.com/asjimene/SCCM-Application-Packager/master/README.md</URL>
 			<DownloadFileName>README.MD</DownloadFileName>


### PR DESCRIPTION
Instruction in ReadMe say to uncomment these lines if you want to package surface drivers.  On first run, I thought I was just creating the template app, but I accidentally downloaded a ton of Surface drivers I didn't need because these lines were un-commented by default and I didn't realize it.